### PR TITLE
Adds a success Alert to display after a topic is created

### DIFF
--- a/src/app/OpenShiftStreams/OpenShiftStreams.tsx
+++ b/src/app/OpenShiftStreams/OpenShiftStreams.tsx
@@ -1,5 +1,8 @@
 import React, {useState} from 'react';
 import {
+  Alert,
+  AlertGroup,
+  AlertActionCloseButton,
   Breadcrumb,
   BreadcrumbItem,
   Button,
@@ -40,6 +43,7 @@ const OpenShiftStreams: React.FunctionComponent = () => {
   const contentRef2 = React.createRef();
   const contentRef3 = React.createRef();
   const contentRef4 = React.createRef();
+  const [alertVisible, setAlertVisible] = useState(true);
 
   const onExpand = () => {
     drawerRef.current && drawerRef.current.focus()
@@ -58,6 +62,10 @@ const OpenShiftStreams: React.FunctionComponent = () => {
     console.log('what is tabIndex  ' + tabIndex);
     setActiveTabKey(tabIndex);
   };
+
+  const handleAlertClose = () => {
+    setAlertVisible(false);
+  }
 
   const mainTabs = (
     <Tabs activeKey={activeTabKey} onSelect={handleTabClick} inset={{default: 'insetMd'}}>
@@ -108,6 +116,25 @@ const OpenShiftStreams: React.FunctionComponent = () => {
             <ClusterConnectionDrawer onCloseClick={onCloseClick} drawerRef={drawerRef} isExpanded={isExpanded}  />
             }>
           <DrawerContentBody>
+            <AlertGroup isToast>
+              { alertVisible ? (
+                <Alert
+                isLiveRegion
+                variant="success"
+                title="OpenShift Streams topic created"
+                actionClose={
+                  <AlertActionCloseButton
+                    aria-label="Close success alert"
+                    onClose={handleAlertClose}
+                  />
+                }
+              >
+                The topic was successfully created in the Kafka instance.
+              </Alert>
+              ) : (
+                <></>
+              )}
+            </AlertGroup>
             <section className="pf-c-page__main-breadcrumb">
               { mainBreadcrumbs }
             </section>


### PR DESCRIPTION
Currently, this alert displays on page load. The code to display the alert after topic creation will be added later.


<img width="1384" alt="image" src="https://user-images.githubusercontent.com/21063328/98599232-a9e35f00-22a9-11eb-931e-dab41e059a7e.png">
