### PR TITLE
Replaces "cluster" with "instance" or "Kafka instance"

### DIFF
--- a/src/app/OpenShiftStreams/OpenShiftStreams.tsx
+++ b/src/app/OpenShiftStreams/OpenShiftStreams.tsx
@@ -118,7 +118,7 @@ const OpenShiftStreams: React.FunctionComponent = () => {
                 </LevelItem>
                 <LevelItem>
                   <Button variant="link" icon={<CodeBranchIcon />} iconPosition="right" onClick={onClusterConnection}>
-                    Connect to this cluster
+                    Connect to this instance
                   </Button>
                 </LevelItem>
               </Level>

--- a/src/app/TabSections/ClusterConnectionDrawer.tsx
+++ b/src/app/TabSections/ClusterConnectionDrawer.tsx
@@ -47,13 +47,13 @@ const ClusterConnectionDrawer: React.FunctionComponent = ({onCloseClick, drawerR
     <>
       <TextContent className="pf-u-pb-sm">
         <Text component={TextVariants.small}>
-          To connect an application or tool to this cluster, you will need the address of a bootstrap server, a certificate and generated credentials.
+          To connect an application or tool to this Kafka instance, you will need the address of a bootstrap server, a certificate and generated credentials.
         </Text>
         <Text component={TextVariants.h5}>
           Bootstrap servers and credentials
         </Text>
         <Text component={TextVariants.small}>
-          Your application or tool will make its initial connection to the cluster using the bootstrap server, and authenticate with credentials specific to the server if required.
+          Your application or tool will make its initial connection to the Kafka instance using the bootstrap server, and authenticate with credentials specific to the server if required.
         </Text>
         <Text component={TextVariants.h5}>
           External server
@@ -72,7 +72,7 @@ const ClusterConnectionDrawer: React.FunctionComponent = ({onCloseClick, drawerR
           Certificates
         </Text>
         <Text component={TextVariants.small}>
-          A certificate is required by your Kafka clients to connect securely to this cluster.
+          A certificate is required by your Kafka clients to connect securely to this Kafka instance.
         </Text>
         <Split hasGutter>
           <SplitItem isFilled>

--- a/src/app/TabSections/CreateTopicsWizardMoreOptions.tsx
+++ b/src/app/TabSections/CreateTopicsWizardMoreOptions.tsx
@@ -397,7 +397,7 @@ const CreateTopicsWizardMoreOptions: React.FunctionComponent = () => {
               Messages
             </Text>
             <Text component={TextVariants.p}>
-              These details control how your messages will be handled in the cluster.
+              These details control how your messages will be handled in the Kafka instance.
             </Text>
           </TextContent>
           <Form>

--- a/src/app/TabSections/Home.tsx
+++ b/src/app/TabSections/Home.tsx
@@ -50,7 +50,7 @@ const Home: React.FunctionComponent = ({isExpanded, setIsExpanded, setIsCreateTo
       "icon": Documentation
     },
     {
-      "title":"Connect to this cluster",
+      "title":"Connect to this instance",
       "description": "Get connection details and sample code to connect your applications.",
       "icon": Connect
     }

--- a/src/app/TabSections/TopicItemProperties.tsx
+++ b/src/app/TabSections/TopicItemProperties.tsx
@@ -223,7 +223,7 @@ const TopicItemProperties: React.FunctionComponent = ({topicName}) => {
               Messages
             </Text>
             <Text component={TextVariants.p}>
-              These details control how your messages will be handled in the cluster.
+              These details control how your messages will be handled in the Kafka instance.
             </Text>
           </TextContent>
           <Form>


### PR DESCRIPTION
"Kafka instance" is used in the context of help text.
"Instance" is used in the context of shorter strings, like action labels.